### PR TITLE
removed winget and fixed taskkill not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,22 @@ Microsoft Edge Remover is helping you to remove Microsoft Edge Legacy and Chromi
 Just right click the `edge-remover.bat` file and click "Open as Administrator". The file can be found in release section or in this repo.
 
 There will be options such as to remove edge with or without restore point etc. Type the letter next to your option and press `Enter` on your keyboard. 
+
+## NOTE:
+If you get the following error:
+`Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor.
+(Exception from HRESULT: 0x80073CFA)
+error 0x80070032: AppX Deployment Remove operation on package
+Microsoft.MicrosoftEdgeDevToolsClient_1000.22621.1.0_neutral_neutral_8wekyb3d8bbwe from:
+C:\Windows\SystemApps\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe failed. This app is part of Windows and
+cannot be uninstalled on a per-user basis. An administrator can attempt to remove the app from the computer using Turn
+Windows Features on or off. However, it may not be possible to uninstall the app.
+NOTE: For additional information, look for [ActivityId] 66f1ae87-e0a9-0005-eb62-f266a9e0d801 in the Event Log or use
+the command line Get-AppPackageLog -ActivityID 66f1ae87-e0a9-0005-eb62-f266a9e0d801
+At line:1 char:35
++ Get-AppxPackage *MicrosoftEdge* | Remove-AppxPackage
++                                   ~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : WriteError: (Microsoft.Micro...l_8wekyb3d8bbwe:String) [Remove-AppxPackage], IOException
+    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand`
+    
+Try [these steps](https://answers.microsoft.com/en-us/windows/forum/all/cant-remove-w10-packages-error-0x80073cfa/c224a864-b604-42b8-a770-57049e0dc50a) mentioned on this Microsoft Issue

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There will be options such as to remove edge with or without restore point etc. 
 
 ## NOTE:
 If you get the following error:
-`Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor.
+``Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor.
 (Exception from HRESULT: 0x80073CFA)
 error 0x80070032: AppX Deployment Remove operation on package
 Microsoft.MicrosoftEdgeDevToolsClient_1000.22621.1.0_neutral_neutral_8wekyb3d8bbwe from:
@@ -29,6 +29,6 @@ At line:1 char:35
 + Get-AppxPackage *MicrosoftEdge* | Remove-AppxPackage
 +                                   ~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : WriteError: (Microsoft.Micro...l_8wekyb3d8bbwe:String) [Remove-AppxPackage], IOException
-    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand`
+    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand``
     
 Try [these steps](https://answers.microsoft.com/en-us/windows/forum/all/cant-remove-w10-packages-error-0x80073cfa/c224a864-b604-42b8-a770-57049e0dc50a) mentioned on this Microsoft Issue

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ There will be options such as to remove edge with or without restore point etc. 
 
 ## NOTE:
 If you get the following error:
-``Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor.
+```
+Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor.
 (Exception from HRESULT: 0x80073CFA)
 error 0x80070032: AppX Deployment Remove operation on package
 Microsoft.MicrosoftEdgeDevToolsClient_1000.22621.1.0_neutral_neutral_8wekyb3d8bbwe from:
@@ -29,6 +30,7 @@ At line:1 char:35
 + Get-AppxPackage *MicrosoftEdge* | Remove-AppxPackage
 +                                   ~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : WriteError: (Microsoft.Micro...l_8wekyb3d8bbwe:String) [Remove-AppxPackage], IOException
-    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand``
+    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand
+```
     
 Try [these steps](https://answers.microsoft.com/en-us/windows/forum/all/cant-remove-w10-packages-error-0x80073cfa/c224a864-b604-42b8-a770-57049e0dc50a) mentioned on this Microsoft Issue

--- a/edge_remover.bat
+++ b/edge_remover.bat
@@ -60,9 +60,8 @@ echo Checking if launched with administrative permissions (Needed to create syst
         exit /b
     )
 :startmse2
-echo First trying to uninstall via winget
-taskkill /F /IM MicrosoftEdge.exe
-winget uninstall -h Microsoft.Edge
+echo KILLING MSEDGE
+taskkill /F /IM msedge.exe
 cd /d "%ProgramFiles(x86)%\Microsoft"
 for /f "tokens=1 delims=\" %%i in ('dir /B /A:D "%ProgramFiles(x86)%\Microsoft\Edge\Application" ^| find "."') do (set "edge_chromium_package_version=%%i")
 if defined edge_chromium_package_version (


### PR DESCRIPTION
winget was causing problems and would prevent uninstall for no reason so removed that and fixed taskkill not working and now closes the correct process `msedge.exe`